### PR TITLE
Void Stuff catagory tooltip

### DIFF
--- a/Runtime/Code/ScriptableObjects/DirectorCards/MSInteractableDirectorCard.cs
+++ b/Runtime/Code/ScriptableObjects/DirectorCards/MSInteractableDirectorCard.cs
@@ -32,7 +32,8 @@ namespace Moonstorm
             "\nDrones: 14" +
             "\nMisc: 7" +
             "\nRare: 0.4" +
-            "\nDuplicator: 8")]
+            "\nDuplicator: 8" +
+            "\nVoid Stuff: 3")]
         public float customCategoryWeight = 1;
 
         [Tooltip("The stages where this interactable can spawn")]


### PR DESCRIPTION
Add Void Stuff catagory to the list of vanilla catagory weights in customCatagory tooltip for MSInteractableDirectorCard