### PR TITLE
shaderswap restores shaders properly

### DIFF
--- a/Editor/Code/Pipelines/SwapShaders.cs
+++ b/Editor/Code/Pipelines/SwapShaders.cs
@@ -67,6 +67,8 @@ namespace MSU.Editor.Pipelines
                     int renderQueue = material.renderQueue;
                     material.shader = value;
                     material.renderQueue = renderQueue;
+                    if (SwapType == SwapType.HlslToYaml && renderQueue == value.renderQueue)
+                        material.renderQueue = -1;
                     log.Add($"Swapped {MarkdownUtils.GenerateAssetLink(material)}'s shadder ({MarkdownUtils.GenerateAssetLink(shader)}) with {MarkdownUtils.GenerateAssetLink(value)}.");
                     _modifiedMaterials.Add(material);
                 }


### PR DESCRIPTION
when swapping back to YAML shaders, sets the material's renderQueue back to -1 if its using the shader's default renderQueue