### PR TITLE
TargetAssetNameAttribute support

### DIFF
--- a/Runtime/Code/ContentUtil.cs
+++ b/Runtime/Code/ContentUtil.cs
@@ -224,7 +224,8 @@ namespace MSU
             {
                 if (fieldInfo.FieldType.IsSameOrSubclassOf(typeof(TAsset)))
                 {
-                    string name = fieldInfo.Name;
+                    TargetAssetNameAttribute customAttribute = CustomAttributeExtensions.GetCustomAttribute<TargetAssetNameAttribute>(fieldInfo);
+                    string name = ((customAttribute != null) ? customAttribute.targetAssetName : fieldInfo.Name);
                     TAsset val = assets.Find(name);
                     if (val != null)
                     {


### PR DESCRIPTION
Adds support to `PopulateTypeFields` for RoR2's `TargetAssetName` attribute, allowing for retargeting of asset names.